### PR TITLE
The _serialize special view variables of JsonView are now deprecated

### DIFF
--- a/src/Controller/Component/ApiPaginationComponent.php
+++ b/src/Controller/Component/ApiPaginationComponent.php
@@ -57,9 +57,9 @@ class ApiPaginationComponent extends Component
         }
 
         $subject->set($config['key'], $this->pagingInfo);
-        $data = $subject->viewBuilder()->getVar('_serialize') ?? [];
+        $data = $subject->viewBuilder()->getOption('serialize') ?? [];
         $data[] = $config['key'];
-        $subject->set('_serialize', $data);
+        $subject->viewBuilder()->setOption('serialize', $data);
     }
 
     /**


### PR DESCRIPTION
After read https://github.com/bcrowe/cakephp-api-pagination/pull/5#issuecomment-656856385
According to de doc https://book.cakephp.org/4/en/appendices/4-0-migration-guide.html#view