### PR TITLE
Add support to "serialize" option when set to true

### DIFF
--- a/src/Controller/Component/ApiPaginationComponent.php
+++ b/src/Controller/Component/ApiPaginationComponent.php
@@ -59,8 +59,11 @@ class ApiPaginationComponent extends Component
 
         $subject->set($config['key'], $this->pagingInfo);
         $data = $subject->viewBuilder()->getOption('serialize') ?? [];
-        $data[] = $config['key'];
-        $subject->viewBuilder()->setOption('serialize', $data);
+
+        if (is_array($data)) {
+            $data[] = $config['key'];
+            $subject->viewBuilder()->setOption('serialize', $data);
+        }
     }
 
     /**


### PR DESCRIPTION
When the viewBuilder's "serialize" option is set to true, all the view
variables are serialized. Some controllers classes can use this feature
in your 'initialize' methods to avoid set up this option in all your
actions.

[1] - https://api.cakephp.org/4.2/class-Cake.View.JsonView.html
[2] - https://api.cakephp.org/4.2/class-Cake.View.XmlView.html

#### Support to `serialize` option set to true

We can set up the `ApiPagination` component and the `viewBuilder`'s `serialize` option to `true` on `AppController::initialize`.
 
```php
class AppController extends Controller
{
    public function initialize(): void
    {
        parent::initialize();

        $this->loadComponent('RequestHandler');

        $this->loadComponent('BryanCrowe/ApiPagination.ApiPagination', [
            'visible' => [
                'page',
                'nextPage'
            ]
        ]);

        $this->viewBuilder()->setOption('serialize', true);
    }
}
```

Then in our Controllers classes we can apply the pagination

```php
class ArticlesController extends AppController
{

    public function index()
    {
        $this->set('articles', $this->paginate($this->Articles));
    }

}
```

Related Pull Requests:
- https://github.com/bcrowe/cakephp-api-pagination/pull/6