### PR TITLE
Add support for CakePHP 5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3']
+        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
         db-type: [mysql]
         prefer-lowest: ['', 'prefer-lowest']
 
@@ -87,7 +87,7 @@ jobs:
 
     strategy:
       matrix:
-        php-versions: ['7.4']
+        php-versions: ['8.1']
 
     steps:
     - name: Checkout

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,7 +31,9 @@ jobs:
 
     - name: Setup MySQL 8
       if: matrix.db-type == 'mysql'
-      run: docker run --rm --name=mysqld -e MYSQL_ROOT_PASSWORD=root -e MYSQL_DATABASE=cakephp -p 3306:3306 -d mysql:8 --default-authentication-plugin=mysql_native_password --disable-log-bin
+      run: |
+          sudo service mysql start
+          mysql -h 127.0.0.1 -u root -proot -e 'CREATE DATABASE pagination;'
 
     - name: Validate composer.json and composer.lock
       run: composer validate --strict
@@ -66,15 +68,11 @@ jobs:
           composer update
         fi
 
-    - name: Wait for MySQL
-      if: matrix.db-type == 'mysql'
-      run: while ! `mysqladmin ping -h 127.0.0.1 --silent`; do printf 'Waiting for MySQL...\n'; sleep 2; done;
-
     - name: Run PHPUnit testsuite
       run: |
         if [[ ${{ matrix.db-type }} == 'mysql' ]]; then
-          export DB_URL='mysql://root:root@127.0.0.1/cakephp';
-          mysql -h 127.0.0.1 -u root -proot cakephp < ./tests/Schema/articles.sql
+          export DB_URL='mysql://root:root@127.0.0.1/pagination';
+          mysql -h 127.0.0.1 -u root -proot pagination < ./tests/Schema/articles.sql
         fi
         vendor/bin/phpunit --stderr;
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['7.4', '8.0', '8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3', '8.4']
         db-type: [mysql]
         prefer-lowest: ['', 'prefer-lowest']
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,7 +22,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        php-versions: ['8.1', '8.2', '8.3', '8.4']
+        php-versions: ['8.1', '8.2', '8.3']
         db-type: [mysql]
         prefer-lowest: ['', 'prefer-lowest']
 

--- a/composer.json
+++ b/composer.json
@@ -1,9 +1,9 @@
 {
     "name": "bcrowe/cakephp-api-pagination",
-    "description": "CakePHP 4 plugin that injects pagination information into API responses.",
+    "description": "CakePHP 5 plugin that injects pagination information into API responses.",
     "type": "cakephp-plugin",
     "keywords": [
-        "cakephp", "api", "pagination", "cakephp3", "cakephp4"
+        "cakephp", "api", "pagination", "cakephp3", "cakephp4", "cakephp5"
     ],
     "homepage": "https://github.com/bcrowe/cakephp-api-pagination",
     "license": "MIT",
@@ -16,13 +16,13 @@
         }
     ],
     "require": {
-        "php": ">=7.2",
-        "cakephp/cakephp": "^4.2"
+        "php": ">=8.1",
+        "cakephp/cakephp": "^5.0"
     },
     "require-dev": {
-        "phpunit/phpunit" : "^8.5.23",
+        "phpunit/phpunit" : "^10.5.5",
         "scrutinizer/ocular": "1.7",
-        "cakephp/cakephp-codesniffer": "^4.7"
+        "cakephp/cakephp-codesniffer": "^5.0"
     },
     "autoload": {
         "psr-4": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,12 +1,11 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <phpunit bootstrap="./tests/bootstrap.php"
          backupGlobals="false"
-         backupStaticAttributes="false"
          colors="true"
-         verbose="true"
-         convertErrorsToExceptions="true"
-         convertNoticesToExceptions="true"
-         convertWarningsToExceptions="true"
+         displayDetailsOnTestsThatTriggerDeprecations="true"
+         displayDetailsOnTestsThatTriggerErrors="true"
+         displayDetailsOnTestsThatTriggerNotices="true"
+         displayDetailsOnTestsThatTriggerWarnings="true"
          processIsolation="false"
          stopOnFailure="false">
     <testsuites>
@@ -14,24 +13,7 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
-    <listeners>
-        <listener
-            class="\Cake\TestSuite\Fixture\FixtureInjector">
-            <arguments>
-                <object class="\Cake\TestSuite\Fixture\FixtureManager" />
-            </arguments>
-        </listener>
-    </listeners>
-    <filter>
-        <whitelist>
-            <directory suffix=".php">src/</directory>
-        </whitelist>
-    </filter>
-    <logging>
-        <log type="tap" target="build/report.tap"/>
-        <log type="junit" target="build/report.junit.xml"/>
-        <log type="coverage-html" target="build/coverage"/>
-        <log type="coverage-text" target="build/coverage.txt"/>
-        <log type="coverage-clover" target="build/logs/clover.xml"/>
-    </logging>
+    <extensions>
+        <bootstrap class="Cake\TestSuite\Fixture\Extension\PHPUnitExtension"/>
+    </extensions>
 </phpunit>

--- a/src/Controller/Component/ApiPaginationComponent.php
+++ b/src/Controller/Component/ApiPaginationComponent.php
@@ -18,7 +18,7 @@ class ApiPaginationComponent extends Component
      *
      * @var array
      */
-    protected $_defaultConfig = [
+    protected array $_defaultConfig = [
         'key' => 'pagination',
         'aliases' => [],
         'visible' => [],
@@ -29,7 +29,7 @@ class ApiPaginationComponent extends Component
      *
      * @var array
      */
-    protected $pagingInfo = [];
+    protected array $pagingInfo = [];
 
     /**
      * Injects the pagination info into the response if the current request is a
@@ -38,7 +38,7 @@ class ApiPaginationComponent extends Component
      * @param  \Cake\Event\Event $event The Controller.beforeRender event.
      * @return void
      */
-    public function beforeRender(Event $event)
+    public function beforeRender(Event $event): void
     {
         if (!$this->isPaginatedApiRequest()) {
             return;
@@ -75,7 +75,7 @@ class ApiPaginationComponent extends Component
      *
      * @return void
      */
-    protected function setAliases()
+    protected function setAliases(): void
     {
         foreach ($this->getConfig('aliases') as $key => $value) {
             $this->pagingInfo[$value] = $this->pagingInfo[$key];
@@ -89,7 +89,7 @@ class ApiPaginationComponent extends Component
      *
      * @return void
      */
-    protected function setVisibility()
+    protected function setVisibility(): void
     {
         $visible = $this->getConfig('visible');
         foreach ($this->pagingInfo as $key => $value) {
@@ -105,7 +105,7 @@ class ApiPaginationComponent extends Component
      *
      * @return bool True if JSON or XML with paging, otherwise false.
      */
-    protected function isPaginatedApiRequest()
+    protected function isPaginatedApiRequest(): bool
     {
         if (
             $this->getController()->getRequest()->getAttribute('paging')

--- a/src/Controller/Component/ApiPaginationComponent.php
+++ b/src/Controller/Component/ApiPaginationComponent.php
@@ -119,6 +119,13 @@ class ApiPaginationComponent extends Component
             return false;
         }
 
+        // Cake 4 way for the people who want to keep embracing paging attribute pattern
+        if ($this->getController()->getRequest()->getAttribute('paging')) {
+            $this->pagingParams = $this->getController()->getRequest()->getAttribute('paging');
+
+            return !empty($this->pagingParams);
+        }
+
         // Since cake 5, paging params are no longer part of the request attribute.
         // Hence, we check for all the view vars and if paginated interface found then we pick the first one and use it.
         // @see https://github.com/cakephp/cakephp/pull/16317#issuecomment-1045873277

--- a/tests/Fixture/ArticlesFixture.php
+++ b/tests/Fixture/ArticlesFixture.php
@@ -5,9 +5,9 @@ use Cake\TestSuite\Fixture\TestFixture;
 
 class ArticlesFixture extends TestFixture
 {
-    public $table = 'bryancrowe_articles';
+    public string $table = 'bryancrowe_articles';
 
-    public $records = [
+    public array $records = [
         ['title' => 'Post #1', 'body' => 'This is the article body.'],
         ['title' => 'Post #2', 'body' => 'This is the article body.'],
         ['title' => 'Post #3', 'body' => 'This is the article body.'],

--- a/tests/TestCase/Controller/Component/ApiPaginationComponentOnNonConventionalControllerNameTest.php
+++ b/tests/TestCase/Controller/Component/ApiPaginationComponentOnNonConventionalControllerNameTest.php
@@ -1,12 +1,15 @@
 <?php
 declare(strict_types=1);
 
-namespace BryanCrowe\ApiPagination\Test;
+namespace BryanCrowe\ApiPagination\Test\TestCase\Controller\Component;
 
 use BryanCrowe\ApiPagination\Controller\Component\ApiPaginationComponent;
 use BryanCrowe\ApiPagination\TestApp\Controller\ArticlesIndexController;
+use Cake\Controller\Controller;
 use Cake\Event\Event;
+use Cake\Http\Response;
 use Cake\Http\ServerRequest as Request;
+use Cake\ORM\Table;
 use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 
@@ -17,7 +20,15 @@ use Cake\TestSuite\TestCase;
  */
 class ApiPaginationComponentOnNonConventionalControllerNameTest extends TestCase
 {
-    public $fixtures = ['plugin.BryanCrowe/ApiPagination.Articles'];
+    public array $fixtures = ['plugin.BryanCrowe/ApiPagination.Articles'];
+
+    protected ?Request $request = null;
+
+    protected ?Response $response = null;
+
+    protected ?Controller $controller = null;
+
+    protected ?Table $Articles = null;
 
     /**
      * setUp method
@@ -28,7 +39,8 @@ class ApiPaginationComponentOnNonConventionalControllerNameTest extends TestCase
     {
         $this->request = new Request(['url' => '/articles']);
         $this->response = $this->createMock('Cake\Http\Response');
-        $this->controller = new ArticlesIndexController($this->request, $this->response);
+        $this->controller = new ArticlesIndexController($this->request);
+        $this->controller = $this->controller->setResponse($this->response);
         $this->Articles = TableRegistry::getTableLocator()->get('BryanCrowe/ApiPagination.Articles', ['table' => 'bryancrowe_articles']);
         parent::setUp();
     }
@@ -71,12 +83,12 @@ class ApiPaginationComponentOnNonConventionalControllerNameTest extends TestCase
      *
      * @return array[]
      */
-    public function dataForTestVariousModelValueOnNonConventionalController(): array
+    public static function dataForTestVariousModelValueOnNonConventionalController(): array
     {
         return [
             [[], []],
-            [['model' => 'Articles'], $this->getDefaultPagination()],
-            [['model' => 'articles'], $this->getDefaultPagination()],
+            [['model' => 'Articles'], self::getDefaultPagination()],
+            [['model' => 'articles'], self::getDefaultPagination()],
             [['model' => 'NonExistingModel'], []],
         ];
     }
@@ -86,27 +98,27 @@ class ApiPaginationComponentOnNonConventionalControllerNameTest extends TestCase
      *
      * @return array
      */
-    private function getDefaultPagination(): array
+    private static function getDefaultPagination(): array
     {
         return [
-            'count' => 23,
-            'current' => 20,
-            'perPage' => 20,
-            'page' => 1,
-            'requestedPage' => 1,
-            'pageCount' => 2,
-            'start' => 1,
-            'end' => 20,
-            'prevPage' => false,
-            'nextPage' => true,
             'sort' => null,
             'direction' => null,
             'sortDefault' => false,
             'directionDefault' => false,
             'completeSort' => [],
-            'limit' => null,
+            'perPage' => 20,
+            'requestedPage' => 1,
+            'alias' => 'Articles',
             'scope' => null,
-            'finder' => 'all',
+            'limit' => null,
+            'count' => 20,
+            'totalCount' => 23,
+            'pageCount' => 2,
+            'currentPage' => 1,
+            'start' => 1,
+            'end' => 20,
+            'hasPrevPage' => false,
+            'hasNextPage' => true,
         ];
     }
 }

--- a/tests/test_app/TestApp/Controller/ArticlesController.php
+++ b/tests/test_app/TestApp/Controller/ArticlesController.php
@@ -7,8 +7,4 @@ use Cake\Controller\Controller;
 
 class ArticlesController extends Controller
 {
-    public function initialize(): void
-    {
-        parent::initialize();
-    }
 }

--- a/tests/test_app/TestApp/Controller/ArticlesIndexController.php
+++ b/tests/test_app/TestApp/Controller/ArticlesIndexController.php
@@ -7,8 +7,4 @@ use Cake\Controller\Controller;
 
 class ArticlesIndexController extends Controller
 {
-    public function initialize(): void
-    {
-        parent::initialize();
-    }
 }


### PR DESCRIPTION
ref. https://github.com/bcrowe/cakephp-api-pagination/issues/14

@bcrowe The PR can be merged after you move current code into 3.x branch for CakePHP 4 support.

For the support of PHP 8.4, it needs to have CakePHP 5.1 which blocks the users who wants to use cake 5.0. So it's better to include it into a separate minor release.